### PR TITLE
Boolean values is not accepted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "nano-queries",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "nano-queries",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"license": "MIT",
 			"workspaces": [
 				"./docs-site"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nano-queries",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"type": "module",
 	"description": "Simple and powerful database-agnostic query builder (SQL & NoSQL)",
 	"keywords": [

--- a/src/QueryBuilder.test.ts
+++ b/src/QueryBuilder.test.ts
@@ -1,5 +1,6 @@
 import { SQLCompiler } from './compilers/SQLCompiler';
 import { PreparedValue } from './core/PreparedValue';
+import { RawSegment } from './core/RawSegment';
 import { QueryBuilder } from './QueryBuilder';
 
 const compiler = new SQLCompiler();
@@ -50,5 +51,24 @@ test('Builder respects a join option', () => {
 	).toEqual({
 		sql: 'SELECT * FROM foo WHERE foo IN (SELECT id FROM bar WHERE x > ?)',
 		bindings: [100],
+	});
+});
+
+test('Any values, including unexpected objects, converts to a bindings', () => {
+	const date = new Date();
+	const symbol = Symbol();
+	const segment = new RawSegment('injection!!!');
+	expect(
+		compiler.toSQL(
+			new QueryBuilder({ join: null })
+				.value(date as any)
+				.value(symbol as any)
+				.value(segment as any)
+				.value({} as any)
+				.value([] as any),
+		),
+	).toEqual({
+		sql: '?????',
+		bindings: [date, symbol, segment, {}, []],
 	});
 });

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -1,14 +1,14 @@
 import { PreparedValue } from './core/PreparedValue';
 import { Query } from './core/Query';
 import { RawSegment } from './core/RawSegment';
-import { IQuery, PrimitiveValue, QuerySegment, RawQueryParameter } from './types';
+import { BaseValues, IQuery, QuerySegment, RawQueryParameter } from './types';
 import { isEmptySegment } from './utils/segments';
 
 export type QueryConstructorOptions = {
 	join?: string | null;
 };
 
-export class QueryBuilder extends Query implements IQuery {
+export class QueryBuilder<T = BaseValues> extends Query<T> implements IQuery<T> {
 	private readonly options;
 	constructor({ join = null }: QueryConstructorOptions = {}) {
 		super();
@@ -16,19 +16,19 @@ export class QueryBuilder extends Query implements IQuery {
 		this.options = { join };
 	}
 
-	public raw(...segments: RawQueryParameter[]) {
+	public raw(...segments: RawQueryParameter<T>[]) {
 		this.addSegment(...segments);
 		return this;
 	}
 
-	public value = (value: PrimitiveValue) => {
+	public value = (value: T) => {
 		return this.raw(new PreparedValue(value));
 	};
 
 	public getSegments() {
 		const { join } = this.options;
 
-		const preparedQuery: QuerySegment[] = [];
+		const preparedQuery: QuerySegment<T>[] = [];
 		this.segments.forEach((segment) => {
 			if (isEmptySegment(segment)) return;
 

--- a/src/TemplateStringQueryBuilder.ts
+++ b/src/TemplateStringQueryBuilder.ts
@@ -2,12 +2,12 @@ import { PreparedValue } from './core/PreparedValue';
 import { Query } from './core/Query';
 import { RawSegment } from './core/RawSegment';
 import { QueryBuilder } from './QueryBuilder';
-import { BaseValues, QuerySegment } from './types';
+import { BaseValues, QuerySegment, RawQueryParameter } from './types';
 
 export class TemplateStringQueryBuilder<T = BaseValues> {
 	public build(
 		strings: TemplateStringsArray,
-		...params: Array<T | QuerySegment<T>>
+		...params: Array<T | QuerySegment<T> | undefined>
 	): Query<T> {
 		const query = new QueryBuilder<T>();
 
@@ -19,11 +19,12 @@ export class TemplateStringQueryBuilder<T = BaseValues> {
 				const parameter = params[index];
 
 				if (
+					parameter === undefined ||
 					parameter instanceof Query<T> ||
 					parameter instanceof RawSegment ||
 					parameter instanceof PreparedValue
 				) {
-					query.raw(parameter);
+					query.raw(parameter as RawQueryParameter<T>);
 				} else {
 					query.value(parameter);
 				}

--- a/src/TemplateStringQueryBuilder.ts
+++ b/src/TemplateStringQueryBuilder.ts
@@ -1,13 +1,15 @@
+import { PreparedValue } from './core/PreparedValue';
 import { Query } from './core/Query';
+import { RawSegment } from './core/RawSegment';
 import { QueryBuilder } from './QueryBuilder';
-import { PrimitiveValue } from './types';
+import { BaseValues, QuerySegment } from './types';
 
-export class TemplateStringQueryBuilder {
+export class TemplateStringQueryBuilder<T = BaseValues> {
 	public build(
 		strings: TemplateStringsArray,
-		...params: Array<PrimitiveValue | Query>
-	): Query {
-		const query = new QueryBuilder();
+		...params: Array<T | QuerySegment<T>>
+	): Query<T> {
+		const query = new QueryBuilder<T>();
 
 		strings.forEach((rawCode, index, items) => {
 			query.raw(rawCode);
@@ -16,7 +18,11 @@ export class TemplateStringQueryBuilder {
 			if (index < lastItemIndex) {
 				const parameter = params[index];
 
-				if (parameter instanceof Query) {
+				if (
+					parameter instanceof Query<T> ||
+					parameter instanceof RawSegment ||
+					parameter instanceof PreparedValue
+				) {
 					query.raw(parameter);
 				} else {
 					query.value(parameter);

--- a/src/compilers/SQLCompiler.test.ts
+++ b/src/compilers/SQLCompiler.test.ts
@@ -169,6 +169,7 @@ test('Compiler run hook to transform values', () => {
 		},
 	});
 
+	// Flat query
 	expect(
 		compiler.compile(
 			new Query<AllowedValues>(
@@ -182,6 +183,31 @@ test('Compiler run hook to transform values', () => {
 				new PreparedValue(true),
 				new RawSegment(' AND is_deleted='),
 				new PreparedValue(false),
+			),
+		),
+	).toEqual({
+		command: 'SELECT * FROM foo WHERE x=? AND is_visible=? AND is_deleted=?',
+		bindings: [100_000, 1, 0],
+	});
+
+	// Nested query
+	expect(
+		compiler.compile(
+			new Query<AllowedValues>(
+				new RawSegment('SELECT *'),
+				new RawSegment(' '),
+				new Query<AllowedValues>(
+					new RawSegment('FROM foo'),
+					new RawSegment(' '),
+					new RawSegment('WHERE x='),
+					new PreparedValue(100_000),
+					new RawSegment(' AND is_visible='),
+					new PreparedValue(true),
+					new Query<AllowedValues>(
+						new RawSegment(' AND is_deleted='),
+						new PreparedValue(false),
+					),
+				),
 			),
 		),
 	).toEqual({

--- a/src/compilers/SQLCompiler.test.ts
+++ b/src/compilers/SQLCompiler.test.ts
@@ -3,6 +3,7 @@ import { format } from 'sql-formatter';
 import { PreparedValue } from '../core/PreparedValue';
 import { Query } from '../core/Query';
 import { RawSegment } from '../core/RawSegment';
+import { BaseValues } from '../types';
 import { SQLCompiler } from './SQLCompiler';
 
 test('Compiler can process linear queries', () => {
@@ -46,7 +47,7 @@ test('Compiler can process nested queries', () => {
 				new RawSegment('WHERE x='),
 				new PreparedValue(1),
 				new RawSegment(' AND '),
-				new Query(
+				new Query<BaseValues>(
 					new RawSegment('('),
 					new RawSegment('SELECT y FROM bar WHERE n='),
 					new PreparedValue('foo'),
@@ -89,7 +90,7 @@ describe('Compiler options', () => {
 					new RawSegment('WHERE x='),
 					new PreparedValue(1),
 					new RawSegment(' AND '),
-					new Query(
+					new Query<BaseValues>(
 						new RawSegment('('),
 						new RawSegment('SELECT y FROM bar WHERE n='),
 						new PreparedValue('foo'),
@@ -134,7 +135,7 @@ describe('Compiler options', () => {
 					new RawSegment('WHERE x='),
 					new PreparedValue(1),
 					new RawSegment(' AND '),
-					new Query(
+					new Query<BaseValues>(
 						new RawSegment('('),
 						new RawSegment('SELECT y FROM bar WHERE n='),
 						new PreparedValue('foo'),

--- a/src/compilers/SQLCompiler.test.ts
+++ b/src/compilers/SQLCompiler.test.ts
@@ -158,3 +158,34 @@ describe('Compiler options', () => {
 		).toMatchSnapshot();
 	});
 });
+
+test('Compiler run hook to transform values', () => {
+	type AllowedValues = string | number | boolean;
+	const compiler = new SQLCompiler<AllowedValues>({
+		transformValue(value) {
+			// Convert boolean to numeric, to make code work in SQLite for example
+			if (typeof value === 'boolean') return Number(value);
+			return value;
+		},
+	});
+
+	expect(
+		compiler.compile(
+			new Query<AllowedValues>(
+				new RawSegment('SELECT *'),
+				new RawSegment(' '),
+				new RawSegment('FROM foo'),
+				new RawSegment(' '),
+				new RawSegment('WHERE x='),
+				new PreparedValue(100_000),
+				new RawSegment(' AND is_visible='),
+				new PreparedValue(true),
+				new RawSegment(' AND is_deleted='),
+				new PreparedValue(false),
+			),
+		),
+	).toEqual({
+		command: 'SELECT * FROM foo WHERE x=? AND is_visible=? AND is_deleted=?',
+		bindings: [100_000, 1, 0],
+	});
+});

--- a/src/compilers/SQLCompiler.ts
+++ b/src/compilers/SQLCompiler.ts
@@ -1,6 +1,6 @@
 import { PreparedValue } from '../core/PreparedValue';
 import { Query } from '../core/Query';
-import { PrimitiveValue, QueryBindings } from '../types';
+import { BaseValues } from '../types';
 
 export interface CommandWithBindings<T> {
 	command: string;
@@ -8,15 +8,16 @@ export interface CommandWithBindings<T> {
 }
 
 export interface Compiler<T> {
-	compile: (query: Query) => T;
+	compile: (query: Query<T>) => CommandWithBindings<T>;
 }
 
+// TODO: add hook to preprocess values
 export type SQLCompilerConfig = {
 	getPlaceholder: (valueIndex: number) => string;
 	onPostProcess?: (code: string) => string;
 };
 
-export class SQLCompiler implements Compiler<CommandWithBindings<QueryBindings>> {
+export class SQLCompiler<B = BaseValues> implements Compiler<B> {
 	private readonly config: SQLCompilerConfig;
 	constructor(options?: Partial<SQLCompilerConfig>) {
 		this.config = {
@@ -27,14 +28,14 @@ export class SQLCompiler implements Compiler<CommandWithBindings<QueryBindings>>
 	/**
 	 * Compile query to SQL string and bindings
 	 */
-	public compile(query: Query): CommandWithBindings<QueryBindings> {
+	public compile(query: Query<B>): CommandWithBindings<B> {
 		const sharedState = {
 			valueIndex: 0,
 		};
 
-		const processQuery = (query: Query): CommandWithBindings<QueryBindings> => {
+		const processQuery = (query: Query<B>): CommandWithBindings<B> => {
 			let command = '';
-			const bindings: Array<PrimitiveValue> = [];
+			const bindings: Array<B> = [];
 			for (const segment of query.getSegments()) {
 				if (segment instanceof Query) {
 					const data = processQuery(segment);
@@ -72,7 +73,7 @@ export class SQLCompiler implements Compiler<CommandWithBindings<QueryBindings>>
 	/**
 	 * Compile query to SQL string and bindings
 	 */
-	public toSQL = (query: Query): { sql: string; bindings: QueryBindings[] } => {
+	public toSQL = (query: Query<B>): { sql: string; bindings: B[] } => {
 		const { command: sql, bindings } = this.compile(query);
 		return { sql, bindings };
 	};

--- a/src/compilers/SQLCompiler.ts
+++ b/src/compilers/SQLCompiler.ts
@@ -1,6 +1,6 @@
 import { PreparedValue } from '../core/PreparedValue';
 import { Query } from '../core/Query';
-import { QueryBindings } from '../types';
+import { PrimitiveValue, QueryBindings } from '../types';
 
 export interface CommandWithBindings<T> {
 	command: string;
@@ -34,7 +34,7 @@ export class SQLCompiler implements Compiler<CommandWithBindings<QueryBindings>>
 
 		const processQuery = (query: Query): CommandWithBindings<QueryBindings> => {
 			let command = '';
-			const bindings: Array<string | number | null> = [];
+			const bindings: Array<PrimitiveValue> = [];
 			for (const segment of query.getSegments()) {
 				if (segment instanceof Query) {
 					const data = processQuery(segment);

--- a/src/compilers/SQLCompiler.ts
+++ b/src/compilers/SQLCompiler.ts
@@ -11,15 +11,15 @@ export interface Compiler<T> {
 	compile: (query: Query<T>) => CommandWithBindings<T>;
 }
 
-// TODO: add hook to preprocess values
-export type SQLCompilerConfig = {
+export type SQLCompilerConfig<T> = {
 	getPlaceholder: (valueIndex: number) => string;
 	onPostProcess?: (code: string) => string;
+	transformValue?: (value: T) => T;
 };
 
 export class SQLCompiler<B = BaseValues> implements Compiler<B> {
-	private readonly config: SQLCompilerConfig;
-	constructor(options?: Partial<SQLCompilerConfig>) {
+	private readonly config: SQLCompilerConfig<B>;
+	constructor(options?: Partial<SQLCompilerConfig<B>>) {
 		this.config = {
 			...options,
 			getPlaceholder: options?.getPlaceholder ?? (() => '?'),
@@ -35,7 +35,7 @@ export class SQLCompiler<B = BaseValues> implements Compiler<B> {
 
 		const processQuery = (query: Query<B>): CommandWithBindings<B> => {
 			let command = '';
-			const bindings: Array<B> = [];
+			let bindings: Array<B> = [];
 			for (const segment of query.getSegments()) {
 				if (segment instanceof Query) {
 					const data = processQuery(segment);
@@ -56,6 +56,11 @@ export class SQLCompiler<B = BaseValues> implements Compiler<B> {
 				}
 
 				command += segment.getValue();
+			}
+
+			const { transformValue } = this.config;
+			if (transformValue) {
+				bindings = bindings.map((value) => transformValue(value));
 			}
 
 			return { command, bindings };

--- a/src/compilers/SQLCompiler.ts
+++ b/src/compilers/SQLCompiler.ts
@@ -33,9 +33,10 @@ export class SQLCompiler<B = BaseValues> implements Compiler<B> {
 			valueIndex: 0,
 		};
 
+		const { transformValue } = this.config;
 		const processQuery = (query: Query<B>): CommandWithBindings<B> => {
 			let command = '';
-			let bindings: Array<B> = [];
+			const bindings: Array<B> = [];
 			for (const segment of query.getSegments()) {
 				if (segment instanceof Query) {
 					const data = processQuery(segment);
@@ -51,16 +52,15 @@ export class SQLCompiler<B = BaseValues> implements Compiler<B> {
 					sharedState.valueIndex++;
 
 					command += placeholder;
-					bindings.push(segment.getValue());
+					bindings.push(
+						transformValue
+							? transformValue(segment.getValue())
+							: segment.getValue(),
+					);
 					continue;
 				}
 
 				command += segment.getValue();
-			}
-
-			const { transformValue } = this.config;
-			if (transformValue) {
-				bindings = bindings.map((value) => transformValue(value));
 			}
 
 			return { command, bindings };

--- a/src/core/PreparedValue.ts
+++ b/src/core/PreparedValue.ts
@@ -1,6 +1,6 @@
-import { PrimitiveValue } from '../types';
 import { ValueBox } from './ValueBox';
 
-export class PreparedValue<
-	V extends PrimitiveValue = PrimitiveValue,
-> extends ValueBox<V> {}
+/**
+ * User input to use as binding
+ */
+export class PreparedValue<V> extends ValueBox<V> {}

--- a/src/core/PreparedValue.ts
+++ b/src/core/PreparedValue.ts
@@ -2,7 +2,7 @@ import { PrimitiveValue, Value } from '../types';
 
 export class PreparedValue implements Value<PrimitiveValue> {
 	protected readonly value;
-	constructor(value: string | number | null) {
+	constructor(value: PrimitiveValue) {
 		this.value = value;
 	}
 

--- a/src/core/PreparedValue.ts
+++ b/src/core/PreparedValue.ts
@@ -1,14 +1,6 @@
-import { PrimitiveValue, Value } from '../types';
+import { PrimitiveValue } from '../types';
+import { ValueBox } from './ValueBox';
 
-export class PreparedValue<V extends PrimitiveValue = PrimitiveValue>
-	implements Value<V>
-{
-	protected readonly value: V;
-	constructor(value: V) {
-		this.value = value;
-	}
-
-	public getValue = () => {
-		return this.value;
-	};
-}
+export class PreparedValue<
+	V extends PrimitiveValue = PrimitiveValue,
+> extends ValueBox<V> {}

--- a/src/core/PreparedValue.ts
+++ b/src/core/PreparedValue.ts
@@ -1,8 +1,10 @@
 import { PrimitiveValue, Value } from '../types';
 
-export class PreparedValue implements Value<PrimitiveValue> {
-	protected readonly value;
-	constructor(value: PrimitiveValue) {
+export class PreparedValue<V extends PrimitiveValue = PrimitiveValue>
+	implements Value<V>
+{
+	protected readonly value: V;
+	constructor(value: V) {
 		this.value = value;
 	}
 

--- a/src/core/Query.test.ts
+++ b/src/core/Query.test.ts
@@ -5,7 +5,7 @@ const compiler = new SQLCompiler();
 
 test('Primitive values converts to sql', () => {
 	expect(compiler.toSQL(new Query('foo', 'bar', 1, 2, true, false))).toEqual({
-		sql: 'foobar12truefalse',
+		sql: 'foobar12',
 		bindings: [],
 	});
 });
@@ -15,6 +15,10 @@ test('Unexpected values converts to sql', () => {
 	expect(
 		compiler.toSQL(
 			new Query(
+				undefined,
+				true,
+				false,
+				Symbol(),
 				{
 					getValue() {
 						return date;
@@ -33,7 +37,7 @@ test('Unexpected values converts to sql', () => {
 			),
 		),
 	).toEqual({
-		sql: date.toString() + '[object Object]' + 'null',
+		sql: '',
 		bindings: [],
 	});
 });

--- a/src/core/Query.test.ts
+++ b/src/core/Query.test.ts
@@ -1,12 +1,32 @@
 import { SQLCompiler } from '../compilers/SQLCompiler';
+import { PreparedValue } from './PreparedValue';
 import { Query } from './Query';
 
 const compiler = new SQLCompiler();
 
 test('Primitive values converts to sql', () => {
-	expect(compiler.toSQL(new Query('foo', 'bar', 1, 2, true, false))).toEqual({
+	expect(
+		compiler.toSQL(new Query('foo', 'bar', 1, 2, true as any, false as any)),
+	).toEqual({
 		sql: 'foobar12',
 		bindings: [],
+	});
+});
+
+test('Prepared values of any type converts to bindings', () => {
+	type Values = string | Date | Symbol;
+	const compiler = new SQLCompiler<Values>();
+	expect(
+		compiler.toSQL(
+			new Query<Values>(
+				new PreparedValue('hello'),
+				new PreparedValue(new Date()),
+				new PreparedValue(Symbol()),
+			),
+		),
+	).toEqual({
+		sql: '???',
+		bindings: ['hello', expect.any(Date), expect.any(Symbol)],
 	});
 });
 
@@ -16,9 +36,9 @@ test('Unexpected values converts to sql', () => {
 		compiler.toSQL(
 			new Query(
 				undefined,
-				true,
-				false,
-				Symbol(),
+				true as any,
+				false as any,
+				Symbol() as any,
 				{
 					getValue() {
 						return date;

--- a/src/core/Query.test.ts
+++ b/src/core/Query.test.ts
@@ -1,0 +1,39 @@
+import { SQLCompiler } from '../compilers/SQLCompiler';
+import { Query } from './Query';
+
+const compiler = new SQLCompiler();
+
+test('Primitive values converts to sql', () => {
+	expect(compiler.toSQL(new Query('foo', 'bar', 1, 2, true, false))).toEqual({
+		sql: 'foobar12truefalse',
+		bindings: [],
+	});
+});
+
+test('Unexpected values converts to sql', () => {
+	const date = new Date();
+	expect(
+		compiler.toSQL(
+			new Query(
+				{
+					getValue() {
+						return date;
+					},
+				} as any,
+				{
+					getValue() {
+						return {};
+					},
+				} as any,
+				{
+					getValue() {
+						return null;
+					},
+				} as any,
+			),
+		),
+	).toEqual({
+		sql: date.toString() + '[object Object]' + 'null',
+		bindings: [],
+	});
+});

--- a/src/core/Query.ts
+++ b/src/core/Query.ts
@@ -33,6 +33,7 @@ export class Query implements IQuery {
 				switch (typeof segment) {
 					case 'string':
 					case 'number':
+					case 'boolean':
 						return new RawSegment(segment);
 
 					default:

--- a/src/core/Query.ts
+++ b/src/core/Query.ts
@@ -1,13 +1,20 @@
-import { IQuery, QueryParameter, QuerySegment, RawQueryParameter } from '../types';
+import { BaseValues, IQuery, QuerySegment, RawQueryParameter } from '../types';
 import { PreparedValue } from './PreparedValue';
 import { RawSegment } from './RawSegment';
 
-export const filterOutEmptySegments = (segments: RawQueryParameter[]) =>
-	segments.filter((segment) => segment !== undefined) as QueryParameter[];
+export const filterOutEmptySegments = <T>(segments: RawQueryParameter<T>[]) =>
+	segments.filter((segment) => segment !== undefined) as QuerySegment<T>[];
 
-export class Query implements IQuery {
-	protected readonly segments: QuerySegment[] = [];
-	constructor(...segments: RawQueryParameter[]) {
+// TODO: infer type automatically for all items passed to constructor
+// Currently class infer only type of first item appears in array
+
+/**
+ * Query constructor that contains sequence of raw segments and prepared values,
+ * and may convert raw input to a query segments.
+ */
+export class Query<T = BaseValues> implements IQuery<T> {
+	protected readonly segments: QuerySegment<T>[] = [];
+	constructor(...segments: RawQueryParameter<T>[]) {
 		if (segments) {
 			this.addSegment(...segments);
 		}
@@ -28,7 +35,7 @@ export class Query implements IQuery {
 		return this.segments;
 	}
 
-	protected addSegment(...segments: RawQueryParameter[]) {
+	protected addSegment(...segments: RawQueryParameter<T>[]) {
 		// TODO: add UnknownValue container to handle it on compile time
 		// We leave here only valid values
 		loop: for (const segment of segments) {

--- a/src/core/Query.ts
+++ b/src/core/Query.ts
@@ -1,4 +1,5 @@
 import { IQuery, QueryParameter, QuerySegment, RawQueryParameter } from '../types';
+import { PreparedValue } from './PreparedValue';
 import { RawSegment } from './RawSegment';
 
 export const filterOutEmptySegments = (segments: RawQueryParameter[]) =>
@@ -28,18 +29,29 @@ export class Query implements IQuery {
 	}
 
 	protected addSegment(...segments: RawQueryParameter[]) {
-		this.segments.push(
-			...filterOutEmptySegments(segments).map((segment) => {
-				switch (typeof segment) {
-					case 'string':
-					case 'number':
-					case 'boolean':
-						return new RawSegment(segment);
+		// TODO: add UnknownValue container to handle it on compile time
+		// We leave here only valid values
+		loop: for (const segment of segments) {
+			if (segment === null) {
+				this.segments.push(new RawSegment(null));
+				continue;
+			}
 
-					default:
-						return segment === null ? new RawSegment(null) : segment;
-				}
-			}),
-		);
+			switch (typeof segment) {
+				case 'string':
+				case 'number':
+					this.segments.push(new RawSegment(segment));
+					continue loop;
+			}
+
+			if (
+				segment instanceof Query ||
+				segment instanceof PreparedValue ||
+				segment instanceof RawSegment
+			) {
+				this.segments.push(segment);
+				continue;
+			}
+		}
 	}
 }

--- a/src/core/RawSegment.ts
+++ b/src/core/RawSegment.ts
@@ -1,12 +1,4 @@
-import { PrimitiveValue, Value } from '../types';
+import { PrimitiveValue } from '../types';
+import { ValueBox } from './ValueBox';
 
-export class RawSegment implements Value<PrimitiveValue> {
-	protected readonly value;
-	constructor(value: PrimitiveValue) {
-		this.value = value;
-	}
-
-	public getValue = () => {
-		return this.value;
-	};
-}
+export class RawSegment extends ValueBox<PrimitiveValue> {}

--- a/src/core/RawSegment.ts
+++ b/src/core/RawSegment.ts
@@ -2,7 +2,7 @@ import { PrimitiveValue, Value } from '../types';
 
 export class RawSegment implements Value<PrimitiveValue> {
 	protected readonly value;
-	constructor(value: string | number | null) {
+	constructor(value: PrimitiveValue) {
 		this.value = value;
 	}
 

--- a/src/core/RawSegment.ts
+++ b/src/core/RawSegment.ts
@@ -1,4 +1,7 @@
-import { PrimitiveValue } from '../types';
+import { BaseValues } from '../types';
 import { ValueBox } from './ValueBox';
 
-export class RawSegment extends ValueBox<PrimitiveValue> {}
+/**
+ * Raw query text to use as is
+ */
+export class RawSegment extends ValueBox<BaseValues> {}

--- a/src/core/ValueBox.ts
+++ b/src/core/ValueBox.ts
@@ -1,0 +1,12 @@
+import { Value } from '../types';
+
+export class ValueBox<V> implements Value<V> {
+	protected readonly value: V;
+	constructor(value: V) {
+		this.value = value;
+	}
+
+	public getValue = () => {
+		return this.value;
+	};
+}

--- a/src/sql/ConditionClause.ts
+++ b/src/sql/ConditionClause.ts
@@ -1,17 +1,17 @@
 import { filterOutEmptySegments, Query } from '../core/Query';
 import { QueryBuilder } from '../QueryBuilder';
-import { IQuery, QuerySegment, RawQueryParameter } from '../types';
+import { BaseValues, IQuery, QuerySegment, RawQueryParameter } from '../types';
 
-export class ConditionClause extends Query implements IQuery {
+export class ConditionClause<T = BaseValues> extends Query<T> implements IQuery<T> {
 	protected readonly clauses: Array<{
-		clause: QuerySegment;
+		clause: QuerySegment<T>;
 		join: 'AND' | 'OR';
 	}> = [];
 	constructor() {
 		super();
 	}
 
-	public and(...query: RawQueryParameter[]) {
+	public and(...query: RawQueryParameter<T>[]) {
 		const filteredQuery = filterOutEmptySegments(query);
 		if (filteredQuery.length > 0) {
 			this.clauses.push({
@@ -23,7 +23,7 @@ export class ConditionClause extends Query implements IQuery {
 		return this;
 	}
 
-	public or(...query: RawQueryParameter[]) {
+	public or(...query: RawQueryParameter<T>[]) {
 		const filteredQuery = filterOutEmptySegments(query);
 		if (filteredQuery.length > 0) {
 			this.clauses.push({
@@ -35,8 +35,8 @@ export class ConditionClause extends Query implements IQuery {
 		return this;
 	}
 
-	public getSegments(): QuerySegment[] {
-		const query = new QueryBuilder({ join: ' ' });
+	public getSegments(): QuerySegment<T>[] {
+		const query = new QueryBuilder<T>({ join: ' ' });
 
 		if (this.clauses.length > 0) {
 			this.clauses.forEach((clause, index) => {

--- a/src/sql/ConfigurableSQLBuilder.test.ts
+++ b/src/sql/ConfigurableSQLBuilder.test.ts
@@ -101,3 +101,13 @@ test('Empty blocks yields nothing', () => {
 		bindings: [],
 	});
 });
+
+test('Compiler defines an acceptable values types for builder', () => {
+	const compiler = new SQLCompiler<number[] | string>();
+	const qb = new ConfigurableSQLBuilder(compiler);
+
+	expect(compiler.compile(qb.sql`Hello ${qb.values(['foo', [1, 2, 3]])}`)).toEqual({
+		command: 'Hello ?,?',
+		bindings: ['foo', [1, 2, 3]],
+	});
+});

--- a/src/sql/ConfigurableSQLBuilder.test.ts
+++ b/src/sql/ConfigurableSQLBuilder.test.ts
@@ -111,3 +111,17 @@ test('Compiler defines an acceptable values types for builder', () => {
 		bindings: ['foo', [1, 2, 3]],
 	});
 });
+
+test('Templated string accepts and skip `undefined`, to build query conditionally', () => {
+	const compiler = new SQLCompiler();
+	const qb = new ConfigurableSQLBuilder(compiler);
+
+	expect(
+		compiler.compile(
+			qb.sql`Hello ${qb.sql`world`}. 1+1=${false ? qb.sql`three` : undefined}${true ? qb.sql`two` : undefined}`,
+		),
+	).toEqual({
+		command: 'Hello world. 1+1=two',
+		bindings: [],
+	});
+});

--- a/src/sql/ConfigurableSQLBuilder.ts
+++ b/src/sql/ConfigurableSQLBuilder.ts
@@ -54,6 +54,8 @@ export class ConfigurableSQLBuilder<T = BaseValues> {
 	};
 
 	private readonly templateStringBuilder = new TemplateStringQueryBuilder<T>();
-	public sql = (strings: TemplateStringsArray, ...params: Array<T | QuerySegment<T>>) =>
-		this.templateStringBuilder.build(strings, ...params);
+	public sql = (
+		strings: TemplateStringsArray,
+		...params: Array<T | QuerySegment<T> | undefined>
+	) => this.templateStringBuilder.build(strings, ...params);
 }

--- a/src/sql/ConfigurableSQLBuilder.ts
+++ b/src/sql/ConfigurableSQLBuilder.ts
@@ -3,56 +3,57 @@ import { PreparedValue } from '../core/PreparedValue';
 import { Query } from '../core/Query';
 import { QueryBuilder } from '../QueryBuilder';
 import { TemplateStringQueryBuilder } from '../TemplateStringQueryBuilder';
-import { PrimitiveValue, QueryBindings, RawQueryParameter } from '../types';
+import { BaseValues, QuerySegment, RawQueryParameter } from '../types';
 import { ConditionClause } from './ConditionClause';
 import { GroupExpression } from './GroupExpression';
 import { LimitClause } from './LimitClause';
-import { SelectStatement, SelectStatementOptions } from './SelectStatement';
+import { SelectStatement } from './SelectStatement';
 import { SetExpression } from './SetExpression';
 import { WhereClause } from './WhereClause';
 
-export class ConfigurableSQLBuilder {
+export class ConfigurableSQLBuilder<T = BaseValues> {
 	private readonly compiler;
-	constructor(compiler: SQLCompiler) {
+	constructor(compiler: SQLCompiler<T>) {
 		this.compiler = compiler;
 	}
 
-	public raw = (...segments: RawQueryParameter[]) =>
-		new QueryBuilder().raw(...segments);
-	public line = (...segments: RawQueryParameter[]) =>
-		new QueryBuilder({ join: ' ' }).raw(...segments);
-	public group = (...segments: RawQueryParameter[]) => new GroupExpression(...segments);
-	public set = (segments: RawQueryParameter[]) => new SetExpression(...segments);
-	public value = (value: QueryBindings) => new PreparedValue(value);
-	public values = (values: Array<QueryBindings> | Record<string, QueryBindings>) => {
+	public raw = (...segments: RawQueryParameter<T>[]) =>
+		new QueryBuilder<T>().raw(...segments);
+	public line = (...segments: RawQueryParameter<T>[]) =>
+		new QueryBuilder<T>({ join: ' ' }).raw(...segments);
+	public group = (...segments: RawQueryParameter<T>[]) =>
+		new GroupExpression<T>(...segments);
+	public set = (segments: RawQueryParameter<T>[]) => new SetExpression(...segments);
+	public value = (value: T) => new PreparedValue(value);
+	public values = (values: Array<T> | Record<string, T>) => {
 		if (Array.isArray(values)) {
-			return new SetExpression(...values.map((value) => new PreparedValue(value)));
+			return new SetExpression(
+				...values.map((value) => new PreparedValue<T>(value)),
+			);
 		}
 
 		return new SetExpression(
 			...Object.entries(values).map(([key, value]) =>
-				new QueryBuilder().raw(key, '=').value(value),
+				new QueryBuilder<T>().raw(key, '=').value(value),
 			),
 		);
 	};
-	public where = (...segments: RawQueryParameter[]) =>
-		new WhereClause().and(...segments);
-	public condition = (...segments: RawQueryParameter[]) =>
-		new ConditionClause().and(...segments);
+	public where = (...segments: RawQueryParameter<T>[]) =>
+		new WhereClause<T>().and(...segments);
+	public condition = (...segments: RawQueryParameter<T>[]) =>
+		new ConditionClause<T>().and(...segments);
 	public limit = (limit?: number) => new LimitClause({ limit });
 	public offset = (offset?: number) => new LimitClause({ offset });
-	public select = (...params: SelectStatementOptions) => new SelectStatement(...params);
+	public select = (...params: RawQueryParameter<T>[]) => new SelectStatement(...params);
 
 	/**
 	 * Compile query to SQL string and bindings
 	 */
-	public toSQL = (query: Query): { sql: string; bindings: QueryBindings[] } => {
+	public toSQL = (query: Query<T>): { sql: string; bindings: T[] } => {
 		return this.compiler.toSQL(query);
 	};
 
-	private readonly templateStringBuilder = new TemplateStringQueryBuilder();
-	public sql = (
-		strings: TemplateStringsArray,
-		...params: Array<PrimitiveValue | Query>
-	) => this.templateStringBuilder.build(strings, ...params);
+	private readonly templateStringBuilder = new TemplateStringQueryBuilder<T>();
+	public sql = (strings: TemplateStringsArray, ...params: Array<T | QuerySegment<T>>) =>
+		this.templateStringBuilder.build(strings, ...params);
 }

--- a/src/sql/GroupExpression.ts
+++ b/src/sql/GroupExpression.ts
@@ -1,12 +1,12 @@
 import { Query } from '../core/Query';
-import { IQuery } from '../types';
+import { BaseValues, IQuery } from '../types';
 
-export class GroupExpression extends Query implements IQuery {
+export class GroupExpression<T = BaseValues> extends Query<T> implements IQuery<T> {
 	public getSegments() {
 		const segments = super.getSegments();
 
 		if (segments.length === 0) return [];
 
-		return [new Query('('), ...segments, new Query(')')];
+		return [new Query<T>('('), ...segments, new Query<T>(')')];
 	}
 }

--- a/src/sql/LimitClause.ts
+++ b/src/sql/LimitClause.ts
@@ -1,18 +1,22 @@
 import { Query } from '../core/Query';
 import { QueryBuilder } from '../QueryBuilder';
-import { IQuery, QuerySegment } from '../types';
+import { BaseValues, IQuery, QuerySegment } from '../types';
 
-export class LimitClause extends Query implements IQuery {
+// This class is requires numbers to be supported
+export class LimitClause<T = BaseValues>
+	extends Query<T | number>
+	implements IQuery<T | number>
+{
 	private readonly state;
 	constructor(state: { limit?: number; offset?: number }) {
 		super();
 		this.state = state;
 	}
 
-	public getSegments(): QuerySegment[] {
+	public getSegments(): QuerySegment<T | number>[] {
 		const { limit, offset } = this.state;
 
-		const query = new QueryBuilder({ join: ' ' });
+		const query = new QueryBuilder<T | number>({ join: ' ' });
 
 		if (limit) {
 			query.raw('LIMIT').value(limit);

--- a/src/sql/SelectStatement.ts
+++ b/src/sql/SelectStatement.ts
@@ -1,34 +1,35 @@
 import { Query } from '../core/Query';
 import { QueryBuilder } from '../QueryBuilder';
-import { IQuery, QueryParameter, QuerySegment, RawQueryParameter } from '../types';
+import { BaseValues, IQuery, QuerySegment, RawQueryParameter } from '../types';
 import { LimitClause } from './LimitClause';
 import { SetExpression } from './SetExpression';
 import { WhereClause } from './WhereClause';
 
-export type SelectStatementOptions = QueryParameter[];
-
-export class SelectStatement extends Query implements IQuery {
-	private readonly _select: QueryParameter[];
-	private readonly _from: QueryParameter[];
+export class SelectStatement<T = BaseValues>
+	extends Query<T | number>
+	implements IQuery<T | number>
+{
+	private readonly _select: RawQueryParameter<T>[];
+	private readonly _from: RawQueryParameter<T>[];
 	private readonly _limit: { limit?: number; offset?: number };
 	private readonly _where;
 
-	constructor(...select: SelectStatementOptions) {
+	constructor(...select: RawQueryParameter<T>[]) {
 		super();
 
 		this._select = select;
 		this._from = [];
 		this._limit = {};
 
-		this._where = new WhereClause();
+		this._where = new WhereClause<T>();
 	}
 
-	public select(...params: QueryParameter[]) {
+	public select(...params: RawQueryParameter<T>[]) {
 		this._select.push(...params);
 		return this;
 	}
 
-	public from(...params: QueryParameter[]) {
+	public from(...params: RawQueryParameter<T>[]) {
 		this._from.push(...params);
 		return this;
 	}
@@ -43,13 +44,13 @@ export class SelectStatement extends Query implements IQuery {
 		return this;
 	}
 
-	public where(param: RawQueryParameter, condition: 'and' | 'or' = 'and') {
+	public where(param: RawQueryParameter<T>, condition: 'and' | 'or' = 'and') {
 		this._where[condition](param);
 		return this;
 	}
 
-	public getSegments(): QuerySegment[] {
-		const query = new QueryBuilder({ join: ' ' });
+	public getSegments(): QuerySegment<T | number>[] {
+		const query = new QueryBuilder<T | number>({ join: ' ' });
 
 		query.raw('SELECT');
 
@@ -64,7 +65,7 @@ export class SelectStatement extends Query implements IQuery {
 
 		query.raw(this._where);
 
-		query.raw(new LimitClause(this._limit));
+		query.raw(new LimitClause<T>(this._limit));
 
 		return query.getSegments();
 	}

--- a/src/sql/SetExpression.ts
+++ b/src/sql/SetExpression.ts
@@ -1,24 +1,24 @@
 import { QueryBuilder } from '../QueryBuilder';
-import { IQuery, QuerySegment, RawQueryParameter } from '../types';
+import { BaseValues, IQuery, QuerySegment, RawQueryParameter } from '../types';
 import { GroupExpression } from './GroupExpression';
 
-export class SetExpression extends QueryBuilder implements IQuery {
-	constructor(...segments: RawQueryParameter[]) {
+export class SetExpression<T = BaseValues> extends QueryBuilder<T> implements IQuery<T> {
+	constructor(...segments: RawQueryParameter<T>[]) {
 		super({ join: null });
 
 		this.raw(...segments);
 	}
 
-	public withParenthesis() {
-		return new GroupExpression(this);
+	public withParenthesis(): GroupExpression<T> {
+		return new GroupExpression<T>(this);
 	}
 
-	public getSegments(): QuerySegment[] {
-		const query = new QueryBuilder();
+	public getSegments(): QuerySegment<T>[] {
+		const query = new QueryBuilder<T>();
 
 		super.getSegments().forEach((item, index) => {
 			const preparedItem =
-				item instanceof SetExpression ? item.withParenthesis() : item;
+				item instanceof SetExpression<T> ? item.withParenthesis() : item;
 			query.raw(index > 0 ? ',' : undefined, preparedItem);
 		});
 

--- a/src/sql/WhereClause.ts
+++ b/src/sql/WhereClause.ts
@@ -1,10 +1,10 @@
 import { Query } from '../core/Query';
 import { QueryBuilder } from '../QueryBuilder';
-import { IQuery, QuerySegment, RawQueryParameter } from '../types';
+import { BaseValues, IQuery, QuerySegment, RawQueryParameter } from '../types';
 import { ConditionClause } from './ConditionClause';
 
-export class WhereClause extends Query implements IQuery {
-	protected readonly condition = new ConditionClause();
+export class WhereClause<T = BaseValues> extends Query<T> implements IQuery<T> {
+	protected readonly condition = new ConditionClause<T>();
 	constructor() {
 		super();
 	}
@@ -13,21 +13,23 @@ export class WhereClause extends Query implements IQuery {
 		return this.condition.size();
 	}
 
-	public and(...query: RawQueryParameter[]) {
+	public and(...query: RawQueryParameter<T>[]) {
 		this.condition.and(...query);
 
 		return this;
 	}
 
-	public or(...query: RawQueryParameter[]) {
+	public or(...query: RawQueryParameter<T>[]) {
 		this.condition.or(...query);
 
 		return this;
 	}
 
-	public getSegments(): QuerySegment[] {
+	public getSegments(): QuerySegment<T>[] {
 		if (this.condition.size() === 0) return [];
 
-		return new QueryBuilder({ join: ' ' }).raw('WHERE', this.condition).getSegments();
+		return new QueryBuilder<T>({ join: ' ' })
+			.raw('WHERE', this.condition)
+			.getSegments();
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface Value<T> {
 export type QueryBindings = PrimitiveValue;
 export type QuerySegment = RawSegment | PreparedValue | Query;
 
-export type QueryParameter = QuerySegment | QueryBindings;
+export type QueryParameter = QuerySegment | unknown;
 export type RawQueryParameter = QueryParameter | undefined;
 
 export interface IQuery {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import { PreparedValue } from './core/PreparedValue';
 import { Query } from './core/Query';
 import { RawSegment } from './core/RawSegment';
 
-export type PrimitiveValue = string | number | null;
+export type PrimitiveValue = string | number | null | boolean;
 
 export interface Value<T> {
 	getValue: () => T;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,19 +2,29 @@ import { PreparedValue } from './core/PreparedValue';
 import { Query } from './core/Query';
 import { RawSegment } from './core/RawSegment';
 
-export type PrimitiveValue = string | number | null | boolean;
+/**
+ * Basic values that may be converted to string
+ */
+export type BaseValues = string | number | null;
 
+/**
+ * Box interface
+ */
 export interface Value<T> {
 	getValue: () => T;
 }
 
-export type QueryBindings = PrimitiveValue;
-export type QuerySegment = RawSegment | PreparedValue | Query;
+/**
+ * Entity that contains description of query part
+ */
+export type QuerySegment<T> = RawSegment | PreparedValue<T> | Query<T>;
 
-export type QueryParameter = QuerySegment | unknown;
-export type RawQueryParameter = QueryParameter | undefined;
+/**
+ * Input for parsing and packing into one of `QuerySegment` entities
+ */
+export type RawQueryParameter<T> = QuerySegment<T> | BaseValues | undefined;
 
-export interface IQuery {
+export interface IQuery<T> {
 	/**
 	 * Returns query segments number
 	 */
@@ -24,5 +34,5 @@ export interface IQuery {
 	 * Returns final query that may be preprocessed
 	 * Returned query will be used to compile SQL
 	 */
-	getSegments(): QuerySegment[];
+	getSegments(): QuerySegment<T>[];
 }

--- a/src/utils/segments.ts
+++ b/src/utils/segments.ts
@@ -3,7 +3,7 @@ import { Query } from '../core/Query';
 import { RawSegment } from '../core/RawSegment';
 import { QuerySegment } from '../types';
 
-export const isEmptySegment = (segment: QuerySegment): boolean => {
+export const isEmptySegment = <T>(segment: QuerySegment<T>): boolean => {
 	if (segment instanceof PreparedValue) return false;
 
 	if (segment instanceof RawSegment) {


### PR DESCRIPTION
Closes #45 

## Problem

Code was bound to `PrimitiveValues` type. This type includes strings, numbers and null, but does not include boolean.

This is because we tested this code with SQLite, where no boolean type exist. But another databases have more types to use. For example, postgres supports boolean type and even arrays.

So the root cause is code not enough flexible and bound to specific types.

## Solution

Now all basic primitives have generic type (with default type for most cases) and user may configure types used for some DB on high level like that

```ts
const compiler = new SQLCompiler<number[] | string>();
const qb = new ConfigurableSQLBuilder(compiler);

expect(compiler.compile(qb.sql`Hello ${qb.values(['foo', [1, 2, 3]])}`)).toEqual({
	command: 'Hello ?,?',
	bindings: ['foo', [1, 2, 3]],
});
```

## Changes
- Implemented optional `transformValue` compiler hook to transform values before return bindings